### PR TITLE
JS build improvements

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -3,8 +3,6 @@
   "prod" : {
     "site_name": "w3z local",
     "api_endpoint": "API_ENDPOINT",
-    "gzip": false,
-    "minify": false,
     "google_analytics": "GA ID",
     "favicon": "https://s3-ap-southeast-1.amazonaws.com/static.w3z.in/assets/w3z.png",
     "ads": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-loader": "~6.2.0",
     "babel-preset-es2015": "~6.3.13",
     "babel-preset-react": "~6.3.13",
-    "compression-webpack-plugin": "^0.2.0",
     "css-loader": "~0.23.0",
     "json-loader": "^0.5.4",
     "style-loader": "~0.13.0",

--- a/src/Service.js
+++ b/src/Service.js
@@ -1,11 +1,5 @@
 import Axios from 'axios';
 
-var config = require('../config.json');
-config = config[config.env];
-
-var API_ENDPOINT = config.api_endpoint;
-console.log('API_ENDPOINT', API_ENDPOINT);
-
 var parseUrl = (function () {
   var a = document.createElement('a');
   return function (url) {
@@ -26,8 +20,7 @@ var Service = {
   processLink: function(link){
     link = parseUrl(link);
 
-    return Axios.post(
-      API_ENDPOINT + "/work",
+    return Axios.post("/work",
       {
         protocol: link.protocol + '//',
         url: link.host + link.pathname + link.search + link.hash

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,26 +1,6 @@
 var webpack = require('webpack');
-var CompressionPlugin = require("compression-webpack-plugin");
-
-var config = require('./config.json');
-config = config[config.env];
 
 var plugins = [];
-
-if(config.minify){
-  plugins.push(new webpack.optimize.UglifyJsPlugin({minimize: true}));
-}
-
-if(config.gzip){
-  plugins.push(
-    new CompressionPlugin({
-           asset: "{file}",
-           algorithm: "gzip",
-           regExp: /\.js$|\.html$/,
-           threshold: 10240,
-           minRatio: 0.8
-       })
-     );
-}
 
 module.exports = {
   entry: './src/main.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,7 +100,7 @@ async@^1.3.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@~0.2.6, async@0.2.x:
+async@~0.2.6:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
@@ -811,12 +811,6 @@ commander@^2.9.0:
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-
-compression-webpack-plugin@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-0.2.0.tgz#ce4553a478ad49cbd5374caaa292c9f16beb055f"
-  dependencies:
-    async "0.2.x"
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
1. Minify / gzip removed from webpack config. They can be provided by CDN / externally if required.

2. API_ENDPOINT removed from build and proxied to same host. If API endpoint is required, that will sit in proxy.